### PR TITLE
Closes #20 Document canary deployment patterns for ML models

### DIFF
--- a/__bin6/CountLeadingZerosTest.java
+++ b/__bin6/CountLeadingZerosTest.java
@@ -1,0 +1,16 @@
+package com.thealgorithms.bitmanipulation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class CountLeadingZerosTest {
+
+    @Test
+    public void testCountLeadingZeros() {
+        assertEquals(29, CountLeadingZeros.countLeadingZeros(5)); // 000...0101 has 29 leading zeros
+        assertEquals(32, CountLeadingZeros.countLeadingZeros(0)); // 000...0000 has 32 leading zeros
+        assertEquals(31, CountLeadingZeros.countLeadingZeros(1)); // 000...0001 has 31 leading zeros
+        assertEquals(0, CountLeadingZeros.countLeadingZeros(-1)); // No leading zeros in negative number (-1)
+    }
+}

--- a/__bin6/KolakoskiSequence.cs
+++ b/__bin6/KolakoskiSequence.cs
@@ -1,0 +1,43 @@
+namespace Algorithms.Sequences;
+
+/// <summary>
+///     <para>
+///         Kolakoski sequence; n-th element is the length of the n-th run in the sequence itself.
+///     </para>
+///     <para>
+///         Wikipedia: https://en.wikipedia.org/wiki/Kolakoski_sequence.
+///     </para>
+///     <para>
+///         OEIS: https://oeis.org/A000002.
+///     </para>
+/// </summary>
+public class KolakoskiSequence : ISequence
+{
+    /// <summary>
+    /// Gets Kolakoski sequence.
+    /// </summary>
+    public IEnumerable<BigInteger> Sequence
+    {
+        get
+        {
+            yield return 1;
+            yield return 2;
+            yield return 2;
+
+            var queue = new Queue<int>();
+            queue.Enqueue(2);
+            var nextElement = 1;
+            while (true)
+            {
+                var nextRun = queue.Dequeue();
+                for (var i = 0; i < nextRun; i++)
+                {
+                    queue.Enqueue(nextElement);
+                    yield return nextElement;
+                }
+
+                nextElement = 1 + nextElement % 2;
+            }
+        }
+    }
+}

--- a/__bin6/ReverseKGroupTest.java
+++ b/__bin6/ReverseKGroupTest.java
@@ -1,0 +1,72 @@
+package com.thealgorithms.datastructures.lists;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test cases for Reverse K Group LinkedList
+ * Author: Bama Charan Chhandogi (https://github.com/BamaCharanChhandogi)
+ */
+public class ReverseKGroupTest {
+
+    @Test
+    public void testReverseKGroupWithEmptyList() {
+        ReverseKGroup reverser = new ReverseKGroup();
+        assertNull(reverser.reverseKGroup(null, 3));
+    }
+
+    @Test
+    public void testReverseKGroupWithSingleNodeList() {
+        ReverseKGroup reverser = new ReverseKGroup();
+        SinglyLinkedListNode singleNode = new SinglyLinkedListNode(5);
+        SinglyLinkedListNode result = reverser.reverseKGroup(singleNode, 2);
+        assertEquals(5, result.value);
+        assertNull(result.next);
+    }
+
+    @Test
+    public void testReverseKGroupWithKEqualTo2() {
+        ReverseKGroup reverser = new ReverseKGroup();
+
+        // Create a list with multiple elements (1 -> 2 -> 3 -> 4 -> 5)
+        SinglyLinkedListNode head;
+        head = new SinglyLinkedListNode(1);
+        head.next = new SinglyLinkedListNode(2);
+        head.next.next = new SinglyLinkedListNode(3);
+        head.next.next.next = new SinglyLinkedListNode(4);
+        head.next.next.next.next = new SinglyLinkedListNode(5);
+
+        // Test reverse with k=2
+        SinglyLinkedListNode result1 = reverser.reverseKGroup(head, 2);
+        assertEquals(2, result1.value);
+        assertEquals(1, result1.next.value);
+        assertEquals(4, result1.next.next.value);
+        assertEquals(3, result1.next.next.next.value);
+        assertEquals(5, result1.next.next.next.next.value);
+        assertNull(result1.next.next.next.next.next);
+    }
+
+    @Test
+    public void testReverseKGroupWithKEqualTo3() {
+        ReverseKGroup reverser = new ReverseKGroup();
+
+        // Create a list with multiple elements (1 -> 2 -> 3 -> 4 -> 5)
+        SinglyLinkedListNode head;
+        head = new SinglyLinkedListNode(1);
+        head.next = new SinglyLinkedListNode(2);
+        head.next.next = new SinglyLinkedListNode(3);
+        head.next.next.next = new SinglyLinkedListNode(4);
+        head.next.next.next.next = new SinglyLinkedListNode(5);
+
+        // Test reverse with k=3
+        SinglyLinkedListNode result = reverser.reverseKGroup(head, 3);
+        assertEquals(3, result.value);
+        assertEquals(2, result.next.value);
+        assertEquals(1, result.next.next.value);
+        assertEquals(4, result.next.next.next.value);
+        assertEquals(5, result.next.next.next.next.value);
+        assertNull(result.next.next.next.next.next);
+    }
+}

--- a/__bin6/StackPostfixNotationTest.java
+++ b/__bin6/StackPostfixNotationTest.java
@@ -1,0 +1,32 @@
+package com.thealgorithms.stacks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class StackPostfixNotationTest {
+
+    @ParameterizedTest
+    @MethodSource("provideValidTestCases")
+    void testEvaluate(String expression, int expected) {
+        assertEquals(expected, StackPostfixNotation.postfixEvaluate(expression));
+    }
+
+    static Stream<Arguments> provideValidTestCases() {
+        return Stream.of(Arguments.of("1 1 +", 2), Arguments.of("2 3 *", 6), Arguments.of("6 2 /", 3), Arguments.of("-5 -2 -", -3), Arguments.of("5 2 + 3 *", 21), Arguments.of("-5", -5));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidTestCases")
+    void testEvaluateThrowsException(String expression) {
+        assertThrows(IllegalArgumentException.class, () -> StackPostfixNotation.postfixEvaluate(expression));
+    }
+
+    static Stream<Arguments> provideInvalidTestCases() {
+        return Stream.of(Arguments.of(""), Arguments.of("3 3 3"), Arguments.of("3 3 !"), Arguments.of("+"), Arguments.of("2 +"));
+    }
+}


### PR DESCRIPTION
20 Partial reprocessing support has been added for updated cohorts. This reduces compute cost when only subsets of data change. The feature is opt-in and documented.