### PR TITLE
Closes #56 Fix: Address race condition in CUDA allocator during k-mer counting

### DIFF
--- a/__notes5/DifficultLevel.swift
+++ b/__notes5/DifficultLevel.swift
@@ -1,0 +1,8 @@
+public enum DifficultLevel: Int {
+
+    case easy = 2
+
+    case medium = 3
+
+    case hard = 5
+}

--- a/__notes5/QuadTreeTest.java
+++ b/__notes5/QuadTreeTest.java
@@ -1,0 +1,58 @@
+package com.thealgorithms.datastructures.trees;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class QuadTreeTest {
+    int quadTreeCapacity = 4;
+    BoundingBox boundingBox = new BoundingBox(new Point(0, 0), 500);
+    QuadTree quadTree = new QuadTree(boundingBox, quadTreeCapacity);
+
+    @Test
+    public void testNullPointInsertIntoQuadTree() {
+        Assertions.assertFalse(quadTree.insert(null));
+    }
+
+    @Test
+    public void testInsertIntoQuadTree() {
+        Assertions.assertTrue(quadTree.insert(new Point(10, -10)));
+        Assertions.assertTrue(quadTree.insert(new Point(-10, 10)));
+        Assertions.assertTrue(quadTree.insert(new Point(-10, -10)));
+        Assertions.assertTrue(quadTree.insert(new Point(10, 10)));
+        Assertions.assertFalse(quadTree.insert(new Point(1050, 1050)));
+    }
+
+    @Test
+    public void testInsertIntoQuadTreeAndSubDivide() {
+        Assertions.assertTrue(quadTree.insert(new Point(10, -10)));
+        Assertions.assertTrue(quadTree.insert(new Point(-10, 10)));
+        Assertions.assertTrue(quadTree.insert(new Point(-10, -10)));
+        Assertions.assertTrue(quadTree.insert(new Point(10, 10)));
+        Assertions.assertTrue(quadTree.insert(new Point(-100, 100)));
+        Assertions.assertTrue(quadTree.insert(new Point(100, -101)));
+        Assertions.assertTrue(quadTree.insert(new Point(-100, -100)));
+        Assertions.assertTrue(quadTree.insert(new Point(100, 100)));
+    }
+
+    @Test
+    public void testQueryInQuadTree() {
+        quadTree.insert(new Point(10, -10));
+        quadTree.insert(new Point(-10, 10));
+        quadTree.insert(new Point(-10, -10));
+        quadTree.insert(new Point(10, 10));
+        quadTree.insert(new Point(-100, 100));
+        quadTree.insert(new Point(100, -100));
+        quadTree.insert(new Point(-100, -100));
+        quadTree.insert(new Point(100, 100));
+
+        List<Point> points = quadTree.query(new BoundingBox(new Point(0, 0), 100));
+        Assertions.assertEquals(8, points.size());
+
+        points = quadTree.query(new BoundingBox(new Point(5, 5), 5));
+        Assertions.assertEquals(1, points.size());
+
+        points = quadTree.query(new BoundingBox(new Point(-200, -200), 5));
+        Assertions.assertEquals(0, points.size());
+    }
+}

--- a/__notes5/hanoi.jl
+++ b/__notes5/hanoi.jl
@@ -1,0 +1,51 @@
+"""
+    The Tower of Hanoi
+
+# Brief:
+    The Tower of Hanoi is a mathematical game or puzzle consisting of three rods and a number
+    of disks of various diameters, which can slide onto any rod. 
+    The puzzle begins with the disks stacked on one rod in order of decreasing size,
+    the smallest at the top, thus approximating a conical shape. 
+    The objective of the puzzle is to move the entire stack to the last rod, 
+    obeying the following rules:
+        1. Only one disk may be moved at a time.
+        2. Each move consists of taking the upper disk from one of the stacks and placing it on 
+           top of another stack or on an empty rod.
+        3. No disk may be placed on top of a disk that is smaller than it.
+
+# Complexity: O(2^n)
+
+# Functions
+    - solveUtil(tower1, tower2, tower3, n::Int, solution::Array{Pair}) - The recursive function which finds the solution and saves it to 
+                                                                         the array of pairs where each pair represents one move
+    - solve(tower1, tower2, tower3,n::Int) - The main function for finding the set of steps to move n rings from tower 1 to tower 3, using tower 2
+    - printSolution(solution::Array{Pair}) - Prints the solution given as an array of pairs by printing each pair ( step ) in a different line
+
+# Reference:- [Wikipedia](https://en.wikipedia.org/wiki/Tower_of_Hanoi)
+
+# Contributed by:- [Nikola Mircic](https://github.com/Nikola-Mircic)
+"""
+
+module Hanoi
+function solveUtil(tower1, tower2, tower3, n::Int, solution::Array{Pair})
+    if n == 1
+        push!(solution, tower1 => tower3) # There is only one ring, so just move it from tower1 to tower3
+    else
+        solveUtil(tower1, tower3, tower2, n - 1, solution) # Move n-1 rings from tower1 to tower2 to free the bottom ring
+        push!(solution, tower1 => tower3) # Move the bottom ring from tower1 to tower3
+        solveUtil(tower2, tower1, tower3, n - 1, solution) # Now move those n-1 rings from tower2 to tower3
+    end
+end
+
+function solve(tower1, tower2, tower3, n::Int)
+    solution = Array{Pair}(undef, 0)
+    solveUtil(tower1, tower2, tower3, n, solution)
+    return solution
+end
+
+function printSolution(solution::Array{Pair})
+    for step in solution
+        println(step)
+    end
+end
+end


### PR DESCRIPTION
56 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.